### PR TITLE
org-mode has modified org-highest-priority

### DIFF
--- a/org-fancy-priorities.el
+++ b/org-fancy-priorities.el
@@ -98,7 +98,7 @@ PRIORITY Is a string of just the priority value e.g. \"A\" \"B\" etc."
   (let ((priority-int (string-to-char priority)))
     ;; Check if org-fancy-priorities-list is a list of strings or alists
     (cond ((equal 'string (type-of (car org-fancy-priorities-list)))
-           (let ((index (- priority-int org-highest-priority)))
+           (let ((index (- priority-int org-priority-highest)))
              (if (< index (length org-fancy-priorities-list))
                  (nth index org-fancy-priorities-list)
                (format "[#%s]" priority))))


### PR DESCRIPTION
[Commit: Use `defalias' for priority aliases.
](https://github.com/bzg/org-mode/commit/e062ca71996547bdb98833e51cf79531405c2ad1#diff-cfe1a32c56525d13db03755dbd7b4a01R2386)

Aboving commit changed `defvaralias` to `defalias` , but lets org-fancy-priorities throw the exception:

```
Error during redisplay: (jit-lock-function 628) signaled (void-variable org-highest-priority)
```

So, I modify `org-highest-priority` to its source value - `org-priority-highest` .
